### PR TITLE
Update links to operation samples

### DIFF
--- a/docs/rapid-pro-operations.md
+++ b/docs/rapid-pro-operations.md
@@ -39,4 +39,4 @@ Parameters are passed to functions as query options:
 
 | Template | GET {resource-path}/{functionName}?{@param=value...}                 |
 | -------- | :------------------------------------------------------------------- |
-| Example  | GET http://rapid-pro.org/company/topEmployees?@startDate='2065-06-12' |
+| Example  | GET [http://rapid-pro.org/company/topEmployees?@count=2](https://jetsons.azurewebsites.net/company/employees/topEmployees(count=2)) |

--- a/docs/rapid-pro-operations.md
+++ b/docs/rapid-pro-operations.md
@@ -39,4 +39,4 @@ Parameters are passed to functions as query options:
 
 | Template | GET {resource-path}/{functionName}?{@param=value...}                 |
 | -------- | :------------------------------------------------------------------- |
-| Example  | GET [http://rapid-pro.org/company/topEmployees?@count=2](https://jetsons.azurewebsites.net/company/employees/topEmployees(count=2)) |
+| Example  | GET [http://rapid-pro.org/company/topEmployees?@num=2](https://jetsons.azurewebsites.net/company/employees/topEmployees(num=2)) |


### PR DESCRIPTION
-Added yourFired action and topEmployees function to jetsons sample.
-Changed the parameter for topEmployees from startDate (which is not in the schema) to count.
-Added hotlink to topEmployees. Can't create hotlink to yourFired because it's a POST operation.

Note that the syntax shown for passing parameters to functions is different than what's implemented in the sample service.  The sample service passes the parameters in parens, rather than as query options (passing parameters as query options is not yet supported in the framework I was using)
