### PR TITLE
initial draft of RDSL documents

### DIFF
--- a/docs/rsdl/rapid-pro-rsdl-abnf.md
+++ b/docs/rsdl/rapid-pro-rsdl-abnf.md
@@ -1,6 +1,8 @@
 # RAPID Pro syntax
 
-July 2020
+<p style="font-size: xxx-large">DRAFT</p>
+Initial Draft. July 2020
+
 
 ## Overview
 

--- a/docs/rsdl/rapid-pro-rsdl-abnf.md
+++ b/docs/rsdl/rapid-pro-rsdl-abnf.md
@@ -47,7 +47,8 @@ parameter           = identifier ":" typeReference
 
 typeReference       = typeName [ "?" ] / "[" typeName [ "?" ] "]"
 
-typeName            = integer / string / boolean / double / decimal / "Edm" "." identifier
+typeName            = builtInType / "Edm" "." identifier / identifier
+builtInType         = integer / string / boolean / double / decimal
 
 ```
 

--- a/docs/rsdl/rapid-pro-rsdl-abnf.md
+++ b/docs/rsdl/rapid-pro-rsdl-abnf.md
@@ -1,0 +1,86 @@
+# RAPID Pro syntax
+
+July 2020
+
+## Overview
+
+This grammar uses ABNF as defined by [RFC5234](https://tools.ietf.org/html/rfc5234).
+
+## Syntax rules
+
+- [Model](#model)
+- [Type definition](#type-definition)
+- [Enum definition](#enum-definition)
+- [Service definition](#service-definition)
+- [Core syntax elements](#core-syntax-elements)
+
+### Model
+
+```ABNF
+model               = 1*modelElement
+
+modelElement        = typeDefinition /
+                      serviceDefinition /
+                      enumDefinition
+```
+
+### Type definition
+
+```ABNF
+
+
+typeDefinition      = "type" "{" typeMember "}"
+
+typeMember          = property / function ; property or bound function
+
+property            = \*propertyAnnotation identifier ":" typeReference
+
+propertyAnnotation  = "@" "key"
+
+function            = functionAnnotation identifier
+                      "(" [ parameter *("," parameter) ] ")"
+                      [":" typeReference]
+
+functionAnnotation  = "@" ("action" / "function" )
+
+parameter           = identifier ":" typeReference
+
+typeReference       = typeName [ "?" ] / "[" typeName [ "?" ] "]"
+
+typeName            = integer / string / boolean / double / decimal / "Edm" "." identifier
+
+```
+
+### Enum definition
+
+```ABNF
+
+enumDefinition      = "enum" "{" enumMember "}"
+
+enumMember          = identifier
+
+```
+
+### Service definition
+
+```ABNF
+serviceDefinition   = "service" "{" serviceMember "}"
+
+serviceMember       = entitySet / singleton
+
+entitySet           = identifier ":" "[" identifier "]"
+
+singleton           = identifier ":" identifier
+
+```
+
+### Core syntax elements
+
+```ABNF
+identifier = identInitial \*identSubsequent
+identInitial = ALPHA / "_"
+identSubsequent = ALPHA / "_" / DIGIT
+ALPHA = %x41-5A / %x61-7A
+DIGIT = %x30-39
+
+```

--- a/docs/rsdl/rapid-pro-rsdl-intro.md
+++ b/docs/rsdl/rapid-pro-rsdl-intro.md
@@ -1,0 +1,75 @@
+# Introduction to RAPID Pro schema definition language (RSDL)
+
+RAPID Pro schema definition language (RSDL) is language to describe Web APIs.
+RSDL is based on a [profile](<https://en.wikipedia.org/wiki/Profile_(engineering)>) of the
+[OData](https://en.wikipedia.org/wiki/Open_Data_Protocol) specification with the goal to provide an easy way
+to create a Web API that is compatible with OData and can evolve into a more elaborate version.
+
+## Introductory Example
+
+The core description of the "shape" of the API is given by a RSDL document.
+
+Below is a first example of an RSDL file that describes an API of a service that provides data on companies and their employees
+
+```RSDL
+type company
+{
+    @key stockSymbol: string
+    name: string
+    incorporated: dateTime
+    employees: [employee]
+}
+
+type employee
+{
+    @key id: integer
+    name : string
+    title: string
+    employmentType: employmentType
+}
+
+enum employmentType { salaried hourly }
+
+service {
+    companies: [company]
+    employees: [employee]
+}
+```
+
+With this relatively small API definition, the service can already serve many different requests to create, update, and delete companies and employees and query for them in multiple ways.
+Below is a (incomplete) list of URLs that can be used with the service. Let's assume the web service is hosted on http://example.com
+
+| Request                                                                                              | Comment                                                          |
+| :--------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------- |
+| GET http://example.com/companies                                                                     | List all companies                                               |
+| GET http://example.com/companies/msft                                                                | get the company identified by stock symbol msft                  |
+| GET http://example.com/companies/msft/employees                                                      | get the employees of the company identified by stock symbol msft |
+| GET http://example.com/employees/123567                                                              | get the employee with employee id 123567                         |
+| POST http://example.com/companies/msft <br/> { "name": "futterkiste", "incorporated": "2010-01-01" } | create a new company identified by stock symbol                  |
+| ...                                                                                                  |                                                                  |
+
+## Defining enums in RSDL
+
+## Defining types in RSDL
+
+### filtering collections of objects
+
+### Expanding properties
+
+## Defining top level collections of objects
+
+## Defining top level single objects
+
+## Querying a graph of objects
+
+### Types with keys vs types without
+
+### Navigation from one object to another
+
+## Changing data
+
+### create
+
+### update
+
+### delete

--- a/docs/rsdl/rapid-pro-rsdl-intro.md
+++ b/docs/rsdl/rapid-pro-rsdl-intro.md
@@ -1,5 +1,8 @@
 # Introduction to RAPID Pro schema definition language (RSDL)
 
+<p style="font-size: xxx-large">DRAFT</p>
+
+
 RAPID Pro schema definition language (RSDL) is language to describe Web APIs.
 RSDL is based on a [profile](<https://en.wikipedia.org/wiki/Profile_(engineering)>) of the
 [OData](https://en.wikipedia.org/wiki/Open_Data_Protocol) specification with the goal to provide an easy way

--- a/docs/rsdl/rapid-pro-rsdl-intro.md
+++ b/docs/rsdl/rapid-pro-rsdl-intro.md
@@ -14,7 +14,7 @@ The core description of the "shape" of the API is given by a RSDL document.
 
 Below is a first example of an RSDL file that describes an API of a service that provides data on companies and their employees
 
-```RSDL
+```
 type company
 {
     @key stockSymbol: string

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -91,7 +91,7 @@ And respectively Type definitions without @key properties are mapped to a comple
       "name": {
         "$Type": "rapid.name"
       }
-    },
+    }
 ```
 
 ```XML
@@ -285,6 +285,7 @@ The return type of a function is mapped similar to a property type with the same
           }
         ],
         "$ReturnType": {
+          "$Collection": true,
           "$Type": "Edm.Int32"
         }
       }
@@ -299,7 +300,7 @@ The return type of a function is mapped similar to a property type with the same
 
     <Function Name="bar" IsBound="true" IsComposable="true">
         <Parameter Name="it" Type="rapid.employee" Nullable="false" />
-        <ReturnType Type="Edm.Int32" Nullable="false" />
+        <ReturnType Type="Collection(Edm.Int32)" Nullable="false" />
     </Function>
 ```
 

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -1,5 +1,8 @@
 # RAPID Pro schema definition language
 
+<p style="font-size: xxx-large">DRAFT</p>
+Initial Draft. July 2020
+
 The semantic of RSDL (RAPID Pro schema definition language) can be described by mapping
 syntactical constructs described in [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) to equivalent [CSDL](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html) constructs.
 

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -45,7 +45,7 @@ And respectively Type definitions without @key properties are mapped to a comple
 
 ### Type definitions without @key properties
 
-```RSDL
+```
     type name
     {
         firstName : string
@@ -74,7 +74,7 @@ And respectively Type definitions without @key properties are mapped to a comple
 
 ### Type definitions with @key properties
 
-```RSDL
+```
     type employee
     {
         @key id: integer
@@ -113,7 +113,7 @@ The properties of a type definition are mapped to either a Property or a Navigat
 
 In the following example lets assume, name is mapped to a complete type and employee is mapped to a entity type.
 
-```RSDL
+```
     type company
     {
         @key stockSymbol: string
@@ -164,7 +164,7 @@ Each of these named types can be marked
 - optional via a question mark `?`
 - multi-value via enclosing it in brackets `[` `]`
 
-```RSDL
+```
     type foo
     {
         test1: integer
@@ -214,7 +214,7 @@ The syntactical production rule called "function" is mapped to a bound action or
 
 The binding parameter of the function is inferred from the containing type production rule and named "this"
 
-```RSDL
+```
     type employee
     {
         @key id: integer
@@ -249,7 +249,7 @@ The binding parameter of the function is inferred from the containing type produ
 
 The return type of a function is mapped similar to a property type with the same semantic for `[` `]` and `?`.
 
-```RSDL
+```
     type employee
     {
         @key id: integer
@@ -311,7 +311,7 @@ The return type of a function is mapped similar to a property type with the same
 
 Parameters are similar to properties in that they have a name and reference a type.
 
-```RSDL
+```
     type employee
     {
         @key id: integer
@@ -359,7 +359,7 @@ Parameters are similar to properties in that they have a name and reference a ty
 
 A [enumDefinition](./rapid-pro-rsdl-abnf.md#enumDefinition) is mapped to an CSDL EnumType. The enumeration members values are automatically assigned.
 
-```RSDL
+```
 enum employmentType { salaried hourly }
 ```
 
@@ -381,7 +381,7 @@ enum employmentType { salaried hourly }
 ## Service definition
 
 As mentioned above, every RAPID service model create a CSDL entity container named "default"
-```RSDL
+```
 service {
 }
 ```
@@ -398,7 +398,7 @@ service {
 
 A service definition element of a multi-value type gets mapped to a CSDL entity set.
 
-```RSDL
+```
 service
 {
   employees: [employee]
@@ -414,7 +414,7 @@ In below example, the `company` type has a `ceo` and an `employees` property of 
 
 RAPID does not allow to have multiple entity sets for the same type, so that the binding is always uniquely defined.
 
-```RSDL
+```
 service
 {
     competitors: [company]
@@ -434,7 +434,7 @@ service
 
 A service definition element of a single-value type gets mapped to a CSDL singleton.
 
-```RSDL
+```
 service
 {
   company: company

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -1,0 +1,220 @@
+# RAPID Pro schema definition language
+
+The semantic of RSDL (RAPID Pro schema definition language) can be described by mapping
+syntactical constructs described in [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) to equivalent [CSDL](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html) constructs.
+
+Please refer to [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) for the syntactical constructs of RSDL.
+
+## Model
+
+A [model](./rapid-pro-rsdl-abnf.md#model) is mapped to a CSDL Schema named "rapid", that has an entity container named "default".
+
+```XML
+    <Schema Namespace="rapid" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <EntityContainer Name="default">
+        </EntityContainer>
+    </Schema>
+```
+
+The model's
+[typeDefinition](./rapid-pro-rsdl-abnf.md#type-definition),
+[serviceDefinition](./rapid-pro-rsdl-abnf.md#service-definition), or
+[enumDefinition](./rapid-pro-rsdl-abnf.md#enum-definition) are mapped to the respective constructs below and added to the schema (or container respectively)
+
+## Type definitions
+
+A [typeDefinition](./rapid-pro-rsdl-abnf.md#type-definition) is mapped to either a [entity type](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_EntityType) or a [complex type](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_ComplexType).
+
+Type definitions with one or more properties marked with a @key annotation are mapped to an entity type.
+And respectively Type definitions without @key properties are mapped to a complex type.
+
+### Type definitions without @key properties
+
+```RSDL
+    type name
+    {
+        firstName : string
+        lastName: string
+    }
+```
+
+```XML
+    <ComplexType Name="name">
+        <Property Name="firstName" Type="Edm.String" Nullable="false" />
+        <Property Name="lastName" Type="Edm.String" Nullable="false" />
+    </ComplexType>
+```
+
+### Type definitions with @key properties
+
+```RSDL
+    type employee
+    {
+        @key id: integer
+        name : name
+    }
+```
+
+```XML
+    <EntityType Name="employee">
+        <Key>
+          <PropertyRef Name="id" />
+        </Key>
+        <Property Name="id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="name" Type="rapid.name" Nullable="false" />
+    </EntityType>
+```
+
+### Properties
+
+The properties of a type definition are mapped to either a Property or a NavigationProperty depending on the property's type.
+
+In the following example lets assume, name is mapped to a complete type and employee is mapped to a entity type.
+
+```RSDL
+    type company
+    {
+        @key stockSymbol: string
+        name: name
+        employees: [employee]
+    }
+```
+
+```XML
+    <EntityType Name="company">
+        <Key>
+          <PropertyRef Name="stockSymbol" />
+        </Key>
+        <Property Name="name" Type="Edm.String" Nullable="false" />
+        <NavigationProperty Name="ceo" Type="rapid.employee" Nullable="false" />
+    </EntityType>
+```
+
+#### Property types
+
+The type of a property is one of:
+
+- the enumerations or types defined in the model
+- one of the primitive types defined in the 'typeName' syntax rule
+- any of the primitive EDM type listed in [OData CSDL XML Representation](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#_Toc38530338)
+
+Each of these named types can be marked as
+
+- optional via a question mark `?`
+- multi value via enclosing it in brackets `[` `]`
+
+```RSDL
+    type foo
+    {
+        test1: integer
+        test3: integer?
+        test1: [integer]
+        test4: [integer?]
+    }
+```
+
+```XML
+    <EntityType Name="foo">
+        <Property Name="test1" Type="Edm.Int32" Nullable="false" />
+        <Property Name="test1" Type="Edm.Int32" Nullable="true" />
+        <Property Name="test3" Type="Collection(Edm.Int32)" Nullable="false"/>
+        <Property Name="test4" Type="Collection(Edm.Int32)" Nullable="true"/>
+    </EntityType>
+```
+
+### Functions
+
+The syntactical production rule called "function" is mapped to a bound action or a bound function in CSDL.
+
+- functions without annotation and the ones annotated with @function are mapped to CSDL [Function](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Function)
+- functions with an "@action" annotation are mapped to a CSDL [Action](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Action)
+
+The binding parameter of the function is inferred from the containing type production rule and named "this"
+
+```RSDL
+    type employee
+    {
+        @key id: integer
+
+        foo()
+    }
+```
+
+```XML
+    <Function Name="foo" IsBound="true" IsComposable="true">
+        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+    </Function>
+```
+
+#### Function return type
+
+The return type of a function is mapped similar to a property type with the same semantic for `[` `]` and `?`.
+
+```RSDL
+    type employee
+    {
+        @key id: integer
+
+        foo() : integer
+        bar() : [integer]
+    }
+```
+
+```XML
+    <Function Name="promote" IsBound="true" IsComposable="true">
+        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+        <ReturnType Type="Edm.Int32" Nullable="false" />
+    </Function>
+        <Function Name="promote" IsBound="true" IsComposable="true">
+        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+        <ReturnType Type="Edm.Int32" Nullable="false" />
+    </Function>
+```
+
+#### Functions parameters
+
+Parameters are similar to properties in that they have a name and reference a type.
+
+```RSDL
+type employee
+{
+    @key id: integer
+
+    foo(a: integer, b: [integer?])
+}
+```
+
+```XML
+    <Function Name="foo" IsBound="true" IsComposable="true">
+        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+        <Parameter Type="Edm.Int32" Nullable="false" />
+        <Parameter Type="Collection(Edm.Int32)" Nullable="true" />
+    </Function>
+```
+
+[TODO: decide on optional parameter, how they are different from nullable required parameters, and if that is a feature required now or too much for RAPID]
+
+## Enum definitions
+
+A [enumDefinition](./rapid-pro-rsdl-abnf.md#enumDefinition) is mapped to an CSDL EnumType. The enumeration members values are automatically assigned.
+
+```RSDL
+enum employmentType { salaried hourly }
+```
+
+```XML
+    <EnumType Name="employmentType">
+        <Member Name="salaried" Value="0" />
+        <Member Name="hourly" Value="1" />
+    </EnumType>
+```
+
+## Service definition
+
+## Appendix
+
+### References
+
+- [Semantics](<https://en.wikipedia.org/wiki/Semantics_(computer_science)>)
+- [OData CSDL XML Representation](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_ComplexType)
+- [RAPID Pro repo](https://github.com/standardapi/odata-rapid-pro)

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -9,11 +9,23 @@ Please refer to [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) for the syntacti
 
 A [model](./rapid-pro-rsdl-abnf.md#model) is mapped to a CSDL Schema named "rapid", that has an entity container named "default".
 
+```JSON
+{
+    "$Version": "4.01",
+    "$EntityContainer": "rapid.default",
+    "rapid": {
+        "default": {
+            "$Kind": "EntityContainer"
+        }
+    }
+}
+```
+
 ```XML
-    <Schema Namespace="rapid" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-        <EntityContainer Name="default">
-        </EntityContainer>
-    </Schema>
+<Schema Namespace="rapid" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+    <EntityContainer Name="default">
+    </EntityContainer>
+</Schema>
 ```
 
 The model's
@@ -38,6 +50,18 @@ And respectively Type definitions without @key properties are mapped to a comple
     }
 ```
 
+```JSON
+    "name": {
+      "$Kind": "ComplexType",
+      "firstName": {
+        "$Type": "Edm.String"
+      },
+      "lastName": {
+        "$Type": "Edm.String",
+      }
+    }
+```
+
 ```XML
     <ComplexType Name="name">
         <Property Name="firstName" Type="Edm.String" Nullable="false" />
@@ -53,6 +77,21 @@ And respectively Type definitions without @key properties are mapped to a comple
         @key id: integer
         name : name
     }
+```
+
+```JSON
+    "employee": {
+      "$Kind": "EntityType",
+      "$Key": [
+        "id"
+      ],
+      "id": {
+        "$Type": "Edm.Int32"
+      },
+      "name": {
+        "$Type": "rapid.name"
+      }
+    },
 ```
 
 ```XML
@@ -77,6 +116,22 @@ In the following example lets assume, name is mapped to a complete type and empl
         @key stockSymbol: string
         name: name
         employees: [employee]
+    }
+```
+
+```JSON
+    "company": {
+      "$Kind": "EntityType",
+      "$Key": [
+        "stockSymbol"
+      ],
+      "name": {
+        "$Type": "Edm.String"
+      },
+      "ceo": {
+        "$Kind": "NavigationProperty",
+        "$Type": "rapid.employee"
+      }
     }
 ```
 

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -377,6 +377,71 @@ enum employmentType { salaried hourly }
 
 ## Service definition
 
+As mentioned above, every RAPID service model create a CSDL entity container named "default"
+```RSDL
+service {
+}
+```
+
+```JSON
+    
+```
+
+```XML
+   <EntityContainer Name="default">
+```
+
+### multi-value service element
+
+A service definition element of a multi-value type gets mapped to a CSDL entity set.
+
+```RSDL
+service
+{
+  employees: [employee]
+}
+```
+
+```XML
+  <EntitySet Name="employees" EntityType="rapid.employee" />
+```
+
+If the type is used as a type on a multi-value and as the type of a property of type definitions (i.e. a navigation property in CSDL), the appropriate navigation property bindings get created.
+In below example, the `company` type has a `ceo` and an `employees` property of the same type `employee` (except one is single-value and the other multi-value). The binding in CSDL defines that objects of these properties are bound to the `employees` entity set.
+
+RAPID does not allow to have multiple entity sets for the same type, so that the binding is always uniquely defined.
+
+```RSDL
+service
+{
+    competitors: [company]
+}
+```
+
+```XML
+  <EntitySet Name="competitors" EntityType="rapid.company">
+    <NavigationPropertyBinding Path="ceo" Target="employees" />
+    <NavigationPropertyBinding Path="employees" Target="employees" />
+  </EntitySet>
+```
+
+
+
+### single-value service element
+
+A service definition element of a single-value type gets mapped to a CSDL singleton.
+
+```RSDL
+service
+{
+  company: company
+}
+```
+
+```XML
+   <Singleton Name="company" Type="rapid.company" />
+```
+
 ## Appendix
 
 ### References

--- a/docs/rsdl/rapid-pro-rsdl-semantics.md
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.md
@@ -125,6 +125,9 @@ In the following example lets assume, name is mapped to a complete type and empl
       "$Key": [
         "stockSymbol"
       ],
+      "stockSymbol": {
+        "$Type": "Edm.String"
+      },
       "name": {
         "$Type": "Edm.String"
       },
@@ -149,14 +152,14 @@ In the following example lets assume, name is mapped to a complete type and empl
 
 The type of a property is one of:
 
-- the enumerations or types defined in the model
 - one of the primitive types defined in the 'typeName' syntax rule
 - any of the primitive EDM type listed in [OData CSDL XML Representation](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#_Toc38530338)
+- the types or enums defined in the model
 
-Each of these named types can be marked as
+Each of these named types can be marked
 
 - optional via a question mark `?`
-- multi value via enclosing it in brackets `[` `]`
+- multi-value via enclosing it in brackets `[` `]`
 
 ```RSDL
     type foo
@@ -165,6 +168,28 @@ Each of these named types can be marked as
         test3: integer?
         test1: [integer]
         test4: [integer?]
+    }
+```
+
+```JSON
+  "foo": {
+      "$Kind": "EntityType",
+      "test1": {
+        "$Type": "Edm.Int32"
+      },
+      "test1": {
+        "$Nullable": true,
+        "$Type": "Edm.Int32"
+      },
+      "test3": {
+        "$Collection": true,
+        "$Type": "Edm.Int32"
+      },
+      "test4": {
+        "$Nullable": true,
+        "$Collection": true,
+        "$Type": "Edm.Int32"
+      }
     }
 ```
 
@@ -195,9 +220,25 @@ The binding parameter of the function is inferred from the containing type produ
     }
 ```
 
+```JSON
+   "foo": [
+      {
+        "$Kind": "Function",
+        "$IsBound": true,
+        "$IsComposable": true,
+        "$Parameter": [
+          {
+            "$Name": "it",
+            "$Type": "rapid.employee"
+          }
+        ]
+      }
+    ]
+```
+
 ```XML
     <Function Name="foo" IsBound="true" IsComposable="true">
-        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+        <Parameter Name="it" Type="rapid.employee" Nullable="false" />
     </Function>
 ```
 
@@ -215,13 +256,49 @@ The return type of a function is mapped similar to a property type with the same
     }
 ```
 
+```JSON
+    "foo": [
+      {
+        "$Kind": "Function",
+        "$IsBound": true,
+        "$IsComposable": true,
+        "$Parameter": [
+          {
+            "$Name": "it",
+            "$Type": "rapid.employee"
+          }
+        ],
+        "$ReturnType": {
+          "$Type": "Edm.Int32"
+        }
+      }
+    ],
+    "bar": [
+      {
+        "$Kind": "Function",
+        "$IsBound": true,
+        "$IsComposable": true,
+        "$Parameter": [
+          {
+            "$Name": "it",
+            "$Type": "rapid.employee"
+          }
+        ],
+        "$ReturnType": {
+          "$Type": "Edm.Int32"
+        }
+      }
+    ]
+```
+
 ```XML
-    <Function Name="promote" IsBound="true" IsComposable="true">
-        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+    <Function Name="foo" IsBound="true" IsComposable="true">
+        <Parameter Name="it" Type="rapid.employee" Nullable="false" />
         <ReturnType Type="Edm.Int32" Nullable="false" />
     </Function>
-        <Function Name="promote" IsBound="true" IsComposable="true">
-        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+
+    <Function Name="bar" IsBound="true" IsComposable="true">
+        <Parameter Name="it" Type="rapid.employee" Nullable="false" />
         <ReturnType Type="Edm.Int32" Nullable="false" />
     </Function>
 ```
@@ -231,17 +308,42 @@ The return type of a function is mapped similar to a property type with the same
 Parameters are similar to properties in that they have a name and reference a type.
 
 ```RSDL
-type employee
-{
-    @key id: integer
+    type employee
+    {
+        @key id: integer
+        foo(a: integer, b: [integer?])
+    }
+```
 
-    foo(a: integer, b: [integer?])
-}
+```JSON
+    "foo": [
+      {
+        "$Kind": "Function",
+        "$IsBound": true,
+        "$IsComposable": true,
+        "$Parameter": [
+          {
+            "$Name": "it",
+            "$Type": "rapid.employee"
+          },
+          {
+            "$Name": "a",
+            "$Type": "Edm.Int32"
+          },
+          {
+            "$Name": "b",
+            "$Collection": true,
+            "$Type": "Edm.Int32",
+            "$Nullable": true
+          }
+        ]
+      }
+    ]
 ```
 
 ```XML
     <Function Name="foo" IsBound="true" IsComposable="true">
-        <Parameter Name="this" Type="rapid.employee" Nullable="false" />
+        <Parameter Name="it" Type="rapid.employee" Nullable="false" />
         <Parameter Type="Edm.Int32" Nullable="false" />
         <Parameter Type="Collection(Edm.Int32)" Nullable="true" />
     </Function>
@@ -255,6 +357,14 @@ A [enumDefinition](./rapid-pro-rsdl-abnf.md#enumDefinition) is mapped to an CSDL
 
 ```RSDL
 enum employmentType { salaried hourly }
+```
+
+```JSON
+    "employmentType": {
+      "$Kind": "EnumType",
+      "salaried": 0,
+      "hourly": 1
+    }
 ```
 
 ```XML


### PR DESCRIPTION
Here is the first draft for the syntax of the custom DSL moved over from standardapi/odata-rapid-pro

It is three documents

### syntax 
Syntactical structure in form of ABNF .
This is technically probably not 100% a correct ABNF since I am ignoring everything whitespace related. Adding the whitespace handling makes this probably a lot more noisy.
Happy to look into it for the next iteration.

### sematics 
A document mapping each (syntactical) RSDL construct to the corresponding CSDL

### introduction
A very early draft to explain RSDL without the use of CSDL 

