### PR TITLE
Update rapid-pro-openapi.md and package.json

### DIFF
--- a/docs/related/rapid-pro-openapi.md
+++ b/docs/related/rapid-pro-openapi.md
@@ -7,4 +7,4 @@ OpenAPI is an extremely popular specification for documenting a REST API.
 Because the RAPID profile builds upon REST, it is natural and encouraged for RAPID services to support OpenAPI.
 
 As the RAPID service description defines a superset of what a service might want to document through OpenAPI,
-a [suggested translation](http://docs.oasis-open.org/odata/odata-openapi/v1.0/odata-openapi-v1.0.html) is defined for translating a RAPID service description to OpenAPI.
+a [suggested translation](https://docs.oasis-open.org/odata/odata-openapi/v1.0/odata-openapi-v1.0.html) is defined for translating a RAPID service description to OpenAPI.

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,8 @@
     "lintDocs": "prettier ../docs/spec/**.md ../docs/related/**.md --write"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.61",
-    "@docusaurus/preset-classic": "2.0.0-alpha.61",
+    "@docusaurus/core": "^2.0.0-alpha.61",
+    "@docusaurus/preset-classic": "^2.0.0-alpha.61",
     "classnames": "^2.2.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,8 @@
     "lintDocs": "prettier ../docs/spec/**.md ../docs/related/**.md --write"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.61",
-    "@docusaurus/preset-classic": "^2.0.0-alpha.61",
+    "@docusaurus/core": "2.0.0-alpha.62",
+    "@docusaurus/preset-classic": "2.0.0-alpha.62",
     "classnames": "^2.2.6",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",


### PR DESCRIPTION
Link on http://rapid.rocks/docs/related/openapi is broken. Only visible difference to working links on http://rapid.rocks/docs/related/odata is `https`

Relaxed package dependencies for docusaurus to get `yarn build` running again