### PR TITLE
improved command line argument handling

### DIFF
--- a/tools/rsdl/dotnet/README.md
+++ b/tools/rsdl/dotnet/README.md
@@ -9,9 +9,10 @@ The rapid cli program can be run from this folder with
 
 ```sh
 cd rapid
-dotnet run -- --input sample.rsdl --format JSON
-dotnet run -- --input sample.rsdl --format XML
-dotnet run -- --input sample.rsdl 
+dotnet run -- sample.rsdl --format JSON
+dotnet run -- sample.rsdl --format XML
+dotnet run -- sample.rsdl --format XML.JSON
+dotnet run -- sample.rsdl
 ```
 
 A self contained binary can be generated via

--- a/tools/rsdl/dotnet/rapid/Program.cs
+++ b/tools/rsdl/dotnet/rapid/Program.cs
@@ -1,39 +1,50 @@
-﻿using Newtonsoft.Json;
-using Superpower;
-using System;
+﻿using System;
 using System.IO;
-using Microsoft.OData.Edm.Csdl;
 using System.Diagnostics;
 using System.Collections.Generic;
-using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json.Serialization;
-using System.Reflection;
-using System.Linq;
-using System.Collections;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm;
-using System.Threading;
+using CommandLine;
 
 namespace rsdl.parser
 {
     class Program
     {
-       
-        static void Main(string[] args)
+        public class Options
         {
-            var switchMappings = new Dictionary<string, string>()
+            [Option('v', "verbose", Required = false, HelpText = "Set output to verbose messages.")]
+            public bool Verbose { get; set; }
+
+            [Option('f', "format", Required = false, HelpText = "Specify the format of the generated CSDL.", Default = CsdlFormat.All)]
+            public CsdlFormat Format { get; set; }
+
+            [Value(0, MetaName = "inputPath", HelpText = "Input file-name including path")]
+            public string InputPath { get; set; }
+        }
+
+        static int Main(string[] args)
+        {
+            var parser = new Parser(config =>
             {
-                { "--input", "input" },
-                { "--format", "format" },
-            };
-            var builder = new ConfigurationBuilder().AddCommandLine(args, switchMappings);
-            var config = builder.Build();
+                config.EnableDashDash = true;
+                config.HelpWriter = Console.Out;
+            });
 
-            var input = config["input"];
-            var format = string.IsNullOrWhiteSpace(config["format"]) ? CsdlFormat.All : Enum.Parse<CsdlFormat>(config["format"], true);
+            return parser.ParseArguments<Options>(args)
+                .MapResult(
+                    options => Run(options),
+                    errors => Error(errors));
+        }
 
-            Console.WriteLine($"converting input: '{input}' to CSDL ('{format}') ");
+        private static int Error(IEnumerable<Error> errors)
+        {
+            return 1;
+        }
 
-            Convert(input, format);
+        private static int Run(Options options)
+        {
+            Convert(options.InputPath, options.Format, options.Verbose);
+            return 0;
         }
 
         /// <summary>
@@ -41,54 +52,50 @@ namespace rsdl.parser
         /// </summary>
         /// <param name="inputPath">file name to parse</param>
         /// <param name="format">indicates wether it should be written as XML or JSON CSDL</param>
-        static void Convert(string inputPath, CsdlFormat format)
+        static void Convert(string inputPath, CsdlFormat format, bool verbose = false)
         {
-            var expression = File.ReadAllText(inputPath);
+            var content = File.ReadAllText(inputPath);
 
-            // 1. tokenize
-            var sw = Stopwatch.StartNew();
-            var tokenizer = RdmTokenizer.Tokenizer;
-            var tokenList = tokenizer.Tokenize(expression);
-            sw.Stop();
-            Console.WriteLine("tokenization {0}", sw.Elapsed);
-            // show tokens
-            //foreach (var token in tokenList)
-            //{
-            //    Console.WriteLine(token);
-            //}
+            // Parse RDM model
+            var model = RdmParser.Parse(content, out var diagnostics);
+            if (verbose)
+            {
+                Console.Error.WriteLine("tokenization: {0}", diagnostics.TokenizationTime);
+                Console.Error.WriteLine("parsing:      {0}", diagnostics.ParsingTime);
+            }
 
-            // 2. parse
-            sw.Start();
-            var parser = RdmParser.DataModel;
-            var model = parser.Parse(tokenList);
-            Console.WriteLine("parsing      {0}", sw.Elapsed);
-            //Console.WriteLine(JsonConvert.SerializeObject(model, Formatting.Indented, settings));
-
-            // 3. transform to CSDL
+            // Transform to CSDL
             try
             {
+                var sw = Stopwatch.StartNew();
                 var transformer = new ModelTransformer();
                 var csdlModel = transformer.Transform(model);
-                Console.WriteLine("transforming {0}", sw.Elapsed);
 
-                WriteCsdl(csdlModel, inputPath, format);
+                if (verbose)
+                {
+                    Console.Error.WriteLine("transforming: {0}", sw.Elapsed);
+                }
+                WriteCsdl(csdlModel, inputPath, format, verbose);
             }
             catch (TransformationException ex)
             {
                 using (new ConsoleColorSelector(ConsoleColor.Red))
                 {
-                    Console.WriteLine($"Error: {ex.Message}");
+                    Console.Error.WriteLine($"Error: {ex.Message}");
                 }
             }
         }
-              
 
-        private static void WriteCsdl(IEdmModel model, string inputPath, CsdlFormat format = CsdlFormat.XML)
+
+        private static void WriteCsdl(IEdmModel model, string inputPath, CsdlFormat format = CsdlFormat.XML, bool verbose = false)
         {
             if (format.HasFlag(CsdlFormat.XML))
             {
                 var path = Path.ChangeExtension(inputPath, ".csdl.xml");
-                Console.WriteLine("writing {0}", path);
+                if (verbose)
+                {
+                    Console.Error.WriteLine("writing {0}", path);
+                }
                 using (var file = File.CreateText(path))
                 using (var writer = System.Xml.XmlWriter.Create(file, new System.Xml.XmlWriterSettings { Indent = true }))
                 {
@@ -98,7 +105,10 @@ namespace rsdl.parser
             if (format.HasFlag(CsdlFormat.JSON))
             {
                 var path = Path.ChangeExtension(inputPath, ".csdl.json");
-                Console.WriteLine("writing {0}", path);
+                if (verbose)
+                {
+                    Console.WriteLine("writing {0}", path);
+                }
                 using (var file = File.Create(path))
                 using (var jsonWriter = new System.Text.Json.Utf8JsonWriter(file, new System.Text.Json.JsonWriterOptions { Indented = true }))
                 {

--- a/tools/rsdl/dotnet/rapid/rapid.csproj
+++ b/tools/rsdl/dotnet/rapid/rapid.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.6" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.7.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />

--- a/tools/rsdl/dotnet/rsdl.parser/ParserCombinators.cs
+++ b/tools/rsdl/dotnet/rsdl.parser/ParserCombinators.cs
@@ -1,0 +1,45 @@
+using Superpower;
+using Superpower.Model;
+using Superpower.Parsers;
+
+namespace rsdl.parser
+{
+    internal static class ParserCombinators
+    {
+        public static TokenListParser<TKind, U> OneOf<TKind, U, T1, T2>(
+          TokenListParser<TKind, T1> p1,
+          TokenListParser<TKind, T2> p2)
+          where T1 : U
+          where T2 : U
+        {
+            return (
+                p1.Cast<TKind, T1, U>()
+            ).Or(
+                p2.Cast<TKind, T2, U>()
+            );
+        }
+
+        public static TokenListParser<TKind, U> OneOf<TKind, U, T1, T2, T3>(
+            TokenListParser<TKind, T1> p1,
+            TokenListParser<TKind, T2> p2,
+            TokenListParser<TKind, T3> p3)
+            where T1 : U
+            where T2 : U
+            where T3 : U
+        {
+            return (
+                p1.Cast<TKind, T1, U>()
+            ).Or(
+                p2.Cast<TKind, T2, U>()
+            ).Or(
+                p3.Cast<TKind, T3, U>()
+            );
+        }
+
+        public static TokenListParser<TKind, T> Between<TKind, T>(this TokenListParser<TKind, T> parser, TKind left, TKind right)
+            => parser.Between(Token.EqualTo(left), Token.EqualTo(right));
+
+        public static model.Position GetPosition<TKind>(this Token<TKind> token) =>
+            new model.Position(token.Position.Line, token.Position.Column);
+    }
+}


### PR DESCRIPTION
rewrote the command line argument handling.
leveraging the package  https://www.nuget.org/packages/CommandLineParser
with options 
```
  -v, --verbose         Set output to verbose messages.
  -f, --format          (Default: All) Specify the format of the generated CSDL.
  --help                Display this help screen.
  --version             Display version information.
  inputPath (pos. 0)    Input file-name including path
```