### PR TITLE
add namespace declaration to parser

### DIFF
--- a/tools/rsdl/dotnet/rapid/sample.rsdl
+++ b/tools/rsdl/dotnet/rapid/sample.rsdl
@@ -1,3 +1,5 @@
+namespace "jetsons"
+
 enum employmentType { salaried hourly }
 
 type company

--- a/tools/rsdl/dotnet/rapid/sample.rsdl
+++ b/tools/rsdl/dotnet/rapid/sample.rsdl
@@ -1,4 +1,4 @@
-namespace "jetsons"
+namespace odata.tc.jetsons
 
 enum employmentType { salaried hourly }
 

--- a/tools/rsdl/dotnet/rsdl.models.transformation/ModelBuilder.cs
+++ b/tools/rsdl/dotnet/rsdl.models.transformation/ModelBuilder.cs
@@ -1,19 +1,17 @@
 using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Csdl;
-using Microsoft.OData.Edm.Vocabularies;
-using Microsoft.OData.Edm.Vocabularies.V1;
 using rsdl.parser.model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace rsdl.parser
 {
     internal class ModelBuilder
     {
-        private readonly string namespaceName = "rapid";
+        private const string defaultNamespaceName = "Model";
+
+        private readonly string namespaceName;
 
         private readonly RdmDataModel rdmModel;
 
@@ -21,6 +19,7 @@ namespace rsdl.parser
 
         public ModelBuilder(RdmDataModel schema)
         {
+            this.namespaceName = schema.Namespace?.NamespaceName ?? defaultNamespaceName;
             this.rdmModel = schema;
         }
 

--- a/tools/rsdl/dotnet/rsdl.models/rsdl/parser/AbstractSyntaxTree.cs
+++ b/tools/rsdl/dotnet/rsdl.models/rsdl/parser/AbstractSyntaxTree.cs
@@ -6,8 +6,15 @@ namespace rsdl.parser.model
 {
     public class RdmDataModel
     {
+        public RdmNamespaceDeclaration Namespace { get; set; }
         public IEnumerable<IRdmSchemaElement> Items { get; set; }
     }
+
+    public class RdmNamespaceDeclaration
+    {
+        public string NamespaceName { get; set; }
+    }
+
 
     /// <summary>
     /// current implementation: RdmStructuredType, RdmService

--- a/tools/rsdl/dotnet/rsdl.parser/RdmParser.cs
+++ b/tools/rsdl/dotnet/rsdl.parser/RdmParser.cs
@@ -59,6 +59,11 @@ namespace rsdl.parser
             .EqualTo(RdmToken.Identifier)
             .Select(t => t.ToStringValue());
 
+        static readonly TokenListParser<RdmToken, string> QualifiedIdentifier =
+            from head in Identifier
+            from tail in (from d in Token.EqualTo(RdmToken.FullStop) from i in Identifier select i).Many()
+            select string.Join(".", tail.Prepend(head));
+
         static readonly TokenListParser<RdmToken, string> EdmPrefix =
             from pre in Token.EqualToValue(RdmToken.Identifier, "Edm")
             from dot in Token.EqualTo(RdmToken.FullStop)
@@ -186,7 +191,7 @@ namespace rsdl.parser
 
         static readonly TokenListParser<RdmToken, RdmNamespaceDeclaration> NamespaceDeclaration =
                    from kw in Token.EqualToValue(RdmToken.Identifier, "namespace")
-                   from nm in QuotedString
+                   from nm in QualifiedIdentifier
                    select new RdmNamespaceDeclaration { NamespaceName = nm };
 
         static readonly TokenListParser<RdmToken, model.IRdmSchemaElement> SchemaElement =

--- a/tools/rsdl/dotnet/rsdl.parser/RdmToken.cs
+++ b/tools/rsdl/dotnet/rsdl.parser/RdmToken.cs
@@ -1,0 +1,33 @@
+using Superpower.Display;
+using Superpower.Parsers;
+
+namespace rsdl.parser
+{
+    public enum RdmToken
+    {
+        None,
+        [Token(Category = "number")] Number,
+        [Token(Category = "identifier")] Identifier,
+
+        [Token(Category = "string")] QuotedString,
+
+        [Token(Category = "parentheses", Example = "(")] LeftParentheses,
+        [Token(Category = "parentheses", Example = ")")] RightParentheses,
+        [Token(Category = "parentheses", Example = "[")] LeftBracket,
+        [Token(Category = "parentheses", Example = "]")] RightBracket,
+        [Token(Category = "parentheses", Example = "{")] LeftBrace,
+        [Token(Category = "parentheses", Example = "}")] RightBrace,
+
+        [Token(Category = "operator", Example = "+")] Plus,
+        [Token(Category = "operator", Example = "-")] Minus,
+        [Token(Category = "operator", Example = "*")] Asterisk,
+        [Token(Category = "operator", Example = "/")] Slash,
+        [Token(Category = "operator", Example = "&")] Ampersand,
+        [Token(Category = "operator", Example = "?")] QuestionMark,
+        [Token(Category = "delimiter", Example = ":")] Colon,
+        [Token(Category = "delimiter", Example = "@")] AtSign,
+        [Token(Category = "delimiter", Example = ";")] Semicolon,
+        [Token(Category = "delimiter", Example = ".")] FullStop,
+        [Token(Category = "delimiter", Example = ",")] Comma,
+    }
+}

--- a/tools/rsdl/dotnet/rsdl.parser/RdmTokenizer.cs
+++ b/tools/rsdl/dotnet/rsdl.parser/RdmTokenizer.cs
@@ -1,37 +1,10 @@
 using Superpower;
-using Superpower.Display;
 using Superpower.Model;
 using Superpower.Parsers;
 using System.Collections.Generic;
 
 namespace rsdl.parser
 {
-
-    public enum RdmToken
-    {
-        None,
-        [Token(Category = "number")] Number,
-        [Token(Category = "identifier")] Identifier,
-
-        [Token(Category = "parentheses", Example = "(")] LeftParentheses,
-        [Token(Category = "parentheses", Example = ")")] RightParentheses,
-        [Token(Category = "parentheses", Example = "[")] LeftBracket,
-        [Token(Category = "parentheses", Example = "]")] RightBracket,
-        [Token(Category = "parentheses", Example = "{")] LeftBrace,
-        [Token(Category = "parentheses", Example = "}")] RightBrace,
-
-        [Token(Category = "operator", Example = "+")] Plus,
-        [Token(Category = "operator", Example = "-")] Minus,
-        [Token(Category = "operator", Example = "*")] Asterisk,
-        [Token(Category = "operator", Example = "/")] Slash,
-        [Token(Category = "operator", Example = "&")] Ampersand,
-        [Token(Category = "operator", Example = "?")] QuestionMark,
-        [Token(Category = "delimiter", Example = ":")] Colon,
-        [Token(Category = "delimiter", Example = "@")] AtSign,
-        [Token(Category = "delimiter", Example = ";")] Semicolon,
-        [Token(Category = "delimiter", Example = ".")] FullStop,
-        [Token(Category = "delimiter", Example = ",")] Comma,
-    }
 
     public class RdmTokenizer : Tokenizer<RdmToken>
     {
@@ -57,6 +30,16 @@ namespace rsdl.parser
                     // yield return Result.Value(SchemaDefinitionToken.Comment, next.Location, integer.Remainder);
                     next = integer.Remainder.ConsumeChar();
                 }
+                else if (next.Value == '\"')
+                {
+                    var str = TextParsers.ExtractQuotedString(next.Location);
+                    if (!str.HasValue)
+                        yield return Result.CastEmpty<string, RdmToken>(str);
+
+                    next = str.Remainder.ConsumeChar();
+
+                    yield return Result.Value(RdmToken.QuotedString, str.Location, str.Remainder);
+                }
                 else if (char.IsLetter(next.Value))
                 {
                     var keywordStart = next.Location;
@@ -66,9 +49,7 @@ namespace rsdl.parser
                     } while (next.HasValue && char.IsLetterOrDigit(next.Value));
 
                     yield return Result.Value(RdmToken.Identifier, keywordStart, next.Location);
-                    //var identifier = Identifier.CStyle(next.Location);
-                    //yield return Result.Value(SchemaDefinitionToken.Identifier, next.Location, identifier.Location);
-                    //next = identifier.Remainder.ConsumeChar();
+
                 }
                 else if (char.IsDigit(next.Value))
                 {

--- a/tools/rsdl/dotnet/rsdl.parser/TextParsers.cs
+++ b/tools/rsdl/dotnet/rsdl.parser/TextParsers.cs
@@ -1,0 +1,18 @@
+using Superpower;
+using Superpower.Parsers;
+
+namespace rsdl.parser
+{
+    internal static class TextParsers
+    {
+
+        public static TextParser<char> QuotedStringContentChar =
+                 Span.EqualTo("\"\"").Value('"').Try().Or(Character.ExceptIn('\"', '\r', '\n'));
+
+        public static TextParser<string> ExtractQuotedString =
+            Character.EqualTo('"')
+                .IgnoreThen(QuotedStringContentChar.Many())
+                .Then(s => Character.EqualTo('"').Value(new string(s)));
+
+    }
+}


### PR DESCRIPTION
- add namespace declaration type to AST
- extend parser to read namespace declaration before any of the other schema elements
- fix transformation to CSDL to leverage declared namespace name if present.

fixes #128 