### PR TITLE
Group RSDL topics and reference from Getting Started and Overview.

### DIFF
--- a/docs/rapid-pro.md
+++ b/docs/rapid-pro.md
@@ -16,10 +16,10 @@ there are well defined conventions and semantics that allow them to seamlessly a
 
 The RAPID profile defines conventions and best practices for services that:
 
--   Retrieve and (optionally) update resources using a simple standard REST API
--   Describe their resources, operations and capabilities in an interoperable JSON Format
--   Support common URL patterns and query parameters
--   Support JSON representations that follow well-defined conventions
+- Retrieve and (optionally) update resources using a simple standard REST API
+- Describe their resources, operations and capabilities in an interoperable JSON Format
+- Support common URL patterns and query parameters
+- Support JSON representations that follow well-defined conventions
 
 ## Why REST?
 
@@ -41,7 +41,7 @@ Sweet. Who says you can't have it all?
 
 ## Resource Description
 
-RAPID introduces a simple RAPID Schema Definition Language (RSDL) that can be used to define the shape of your service.
+RAPID introduces a simple RAPID Schema Definition Language (RSDL) that can be used at design time to define the shape of your service.
 
 For example, the following RSDL defines a simple type "Company", returned by the "company" endpoint of the service.
 
@@ -60,7 +60,32 @@ service {
 
 For details on defining a RAPID service using RSDL, see [RAPID Schema Definition Language (RSDL)](./rsdl/rapid-pro-rsdl-intro.md)
 
-At runtime, services describe their resources through a simple and concise JSON representation in order to allow generic clients to interact with the service. For more information on the runtime resource description, see [RAPID Resource Description](./spec/rapid-pro-resource_description.md).
+This simple design time syntax is converted to a runtime service description that client applications and tooling can use to interact with the service.
+
+```json
+{
+  "$Version": "4.01",
+  "jetsons": {
+    "company": {
+      "$Kind": "EntityType",
+      "$Key": ["stockSymbol"],
+      "name": { "Type": "Edm.String" },
+      "incorporated": { "$Type": "Edm.Date" },
+      "stockSymbol": {}
+      }
+    },
+    "Service": {
+      "$Kind": "EntityContainer",
+      "company": {
+        "$Type": "jetsons.company"
+      },
+    },
+    "$EntityContainer": "jetsons.Service"
+  }
+}
+```
+
+For more information on the runtime service description, see [Runtime Service Description](./spec/rapid-pro-resource_description.md).
 
 ## RAPID Requests
 
@@ -134,8 +159,8 @@ is defined for translating a RAPID service description to OpenAPI.
 RAPID is designed to be a profile that applies a subset of the conventions defined in OData applicable to any RESTful API. 
 A RAPID service can easily support generic OData V4 clients by:
 
--   Supporting OData calling conventions
--   Following OData JSON conventions for OData V4 Clients
+- Supporting OData calling conventions
+- Following OData JSON conventions for OData V4 Clients
 
 RAPID services MAY support any additional conventions defined in the OData specification as appropriate to the service.
 

--- a/docs/rapid-pro.md
+++ b/docs/rapid-pro.md
@@ -41,8 +41,26 @@ Sweet. Who says you can't have it all?
 
 ## Resource Description
 
-RAPID services describe their resources through a simple and concise JSON representation in order to allow generic clients to interact with the service. 
-For more information on the RAPID resource description language, see [RAPID Resource Description](./spec/rapid-pro-resource_description.md).
+RAPID introduces a simple RAPID Schema Definition Language (RSDL) that can be used to define the shape of your service.
+
+For example, the following RSDL defines a simple type "Company", returned by the "company" endpoint of the service.
+
+```rsdl
+type Company
+{
+    stockSymbol: String
+    name: String
+    incorporated: Date
+}
+
+service {
+    company: Company
+}
+```
+
+For details on defining a RAPID service using RSDL, see [RAPID Schema Definition Language (RSDL)](./rsdl/rapid-pro-rsdl-intro.md)
+
+At runtime, services describe their resources through a simple and concise JSON representation in order to allow generic clients to interact with the service. For more information on the runtime resource description, see [RAPID Resource Description](./spec/rapid-pro-resource_description.md).
 
 ## RAPID Requests
 

--- a/docs/rsdl/rapid-pro-rsdl-intro.md
+++ b/docs/rsdl/rapid-pro-rsdl-intro.md
@@ -5,7 +5,7 @@ title: RAPID SDL intro
 
 # Introduction to RAPID Schema Definition Language (RSDL)
 
-RAPID Schema Definition Language (RSDL) is a language to describe Web APIs.
+RAPID Schema Definition Language (RSDL) is a language to define Web APIs.
 
 RSDL is based on the [RAPID PROfile](<https://en.wikipedia.org/wiki/Profile_(engineering)>) of the
 [OData](https://en.wikipedia.org/wiki/Open_Data_Protocol) specification. RAPID provides an easy way
@@ -13,11 +13,11 @@ to envision, create, and consume a Web API that is compatible with the OData Sta
 
 ## Introductory Example
 
-RAPID APIs are defined by a schema, which can easily be described through RSDL.
+RAPID APIs are defined by a schema, which can easily be specified using RSDL.
 
 ### Defining a Structured Type
 
-Let's say that we wanted our API to deal with information about a company. We could describe the properties of a company as follows:
+Let's say that we wanted our API to deal with information about a company. We could specify the properties of a company as follows:
 
 ```rsdl
 type Company

--- a/docs/rsdl/rapid-pro-rsdl-semantics.mdx
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.mdx
@@ -7,7 +7,7 @@ title: RAPID Schema Definition Language Semantics
 > Initial Draft. July 2020
 
 The semantic of RSDL (RAPID Schema Definition Language) can be described by mapping
-syntactical constructs described in [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) to equivalent runtime [Resource Definition](../spec/rapid-pro-resource_description.md) constructs.
+syntactical constructs described in [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) to equivalent runtime [Service Definition](../spec/rapid-pro-resource_description.md) constructs.
 
 Please refer to [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) for the syntactical constructs of RSDL.
 

--- a/docs/rsdl/rapid-pro-rsdl-semantics.mdx
+++ b/docs/rsdl/rapid-pro-rsdl-semantics.mdx
@@ -1,13 +1,13 @@
 ---
 id: rsdl-semantics
-title: RAPID Pro Schema Definition Language Semantics
+title: RAPID Schema Definition Language Semantics
 ---
 
 > DRAFT
 > Initial Draft. July 2020
 
-The semantic of RSDL (RAPID Pro Schema Definition Language) can be described by mapping
-syntactical constructs described in [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) to equivalent [CSDL](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html) constructs.
+The semantic of RSDL (RAPID Schema Definition Language) can be described by mapping
+syntactical constructs described in [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) to equivalent runtime [Resource Definition](../spec/rapid-pro-resource_description.md) constructs.
 
 Please refer to [rapid-pro-rsdl-abnf](./rapid-pro-rsdl-abnf.md) for the syntactical constructs of RSDL.
 

--- a/docs/spec/rapid-pro-features.md
+++ b/docs/spec/rapid-pro-features.md
@@ -10,7 +10,8 @@ and because they follow core patterns they can be extended with optional feature
 - [Data Retrieval](../rapid-pro-read.md)
 - [Data Modification](../rapid-pro-data_modification.md)
 - [Actions and Functions](../rapid-pro-operations.md)
-- [Resource Description](./rapid-pro-resource_description.md)
+- [RAPID Schema Definition Language](../rsdl/rapid-pro-rsdl-intro.md)
+- [Runtime Resource Description](./rapid-pro-resource_description.md)
 - [Batch Operations](./rapid-pro-batch.md)
 
 <!--

--- a/docs/spec/rapid-pro-features.md
+++ b/docs/spec/rapid-pro-features.md
@@ -5,14 +5,18 @@ sidebar_label: Overview
 ---
 
 RAPID services can be very simple,
-and because they follow core patterns they can be extended with optional features when needed:
+and because they follow core patterns they can be extended with optional features when needed.
 
+For an overview of RAPID, see [Getting Started](../rapid-pro.md).
+
+The following sections provide more detailed information and walkthroughs for key aspects of RAPID.
+
+- [RAPID Schema Definition Language](../rsdl/rapid-pro-rsdl-intro.md)
 - [Data Retrieval](../rapid-pro-read.md)
 - [Data Modification](../rapid-pro-data_modification.md)
-- [Actions and Functions](../rapid-pro-operations.md)
-- [RAPID Schema Definition Language](../rsdl/rapid-pro-rsdl-intro.md)
-- [Runtime Resource Description](./rapid-pro-resource_description.md)
 - [Batch Operations](./rapid-pro-batch.md)
+- [Actions and Functions](../rapid-pro-operations.md)
+- [Runtime Service Description](./rapid-pro-resource_description.md)
 
 <!--
 -   [Asynchronous Requests](./rapid-pro-asynchronous_requests.md)

--- a/docs/spec/rapid-pro-resource_description.md
+++ b/docs/spec/rapid-pro-resource_description.md
@@ -1,9 +1,9 @@
 ---
-id: resourceformat
-title: Resource Description
+id: servicedescription
+title: Runtime Service Description
 ---
 
-RAPID services describe their resources through a simple and concise JSON representation in order to allow generic clients to interact with the service.
+Client applications and tooling can use a runtime service description to understand how to interact with the service.
 By convention, this description is retrieved by requesting the `/$metadata` resource, located at the root of the service.
 
 | Example | GET [`http://rapid-pro.org/$metadata`](https://jetsons.azurewebsites.net/$metadata)<br/>Accept: application/json |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -15,11 +15,17 @@ module.exports = {
                 'rapid-read',
                 'rapid-edit',
                 'operations',
+                'spec/resourceformat',
+                'spec/batch'
+            ]
+        },
+        {
+            type: 'category',
+            label: 'RAPID Schema Definition Language (RSDL)',
+            items: [
                 'rsdl/rsdl-intro',
                 'rsdl/rsdl-semantics',
                 'rsdl/rsdl-abnf',
-                'spec/resourceformat',
-                'spec/batch'
             ]
         },
         {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -15,7 +15,7 @@ module.exports = {
                 'rapid-read',
                 'rapid-edit',
                 'operations',
-                'spec/resourceformat',
+                'spec/servicedescription',
                 'spec/batch'
             ]
         },


### PR DESCRIPTION
In our walkthrough of docs at the December offsite, we said we wanted to group the RSDL topics in a common category and reference it from the Getting Started and Overview sections.

This PR does that.