### PR TITLE
Issue 162

### DIFF
--- a/tools/rsdl/rapid-cli/rapid.rdm.transformation.tests/IncludeTests.cs
+++ b/tools/rsdl/rapid-cli/rapid.rdm.transformation.tests/IncludeTests.cs
@@ -23,7 +23,7 @@ namespace rapid.rdm.tests
             env.AddReferences(main, new Dictionary<string, RdmDataModel> { ["common"] = incl });
 
             // act
-            var actual = env.ResolveTypeReference(new RdmTypeReference("common.EmploymentType", false));
+            var actual = env.ResolveTypeReference(new RdmTypeReference("common.EmploymentType"));
 
             // assert
             // note that the enumeration has zero members

--- a/tools/rsdl/rapid-cli/rapid.rdm.transformation/TypeEnvironment.cs
+++ b/tools/rsdl/rapid-cli/rapid.rdm.transformation/TypeEnvironment.cs
@@ -59,12 +59,12 @@ namespace rapid.rdm
             // identifier refering to the current model. has precedence over predefined primitive types
             if (this.@internal.TryGetValue(typeRef.Name, out var edmType))
             {
-                return MakeTypeReference(edmType, typeRef.IsNullable);
+                return MakeTypeReference(edmType, typeRef.Facets.IsNullable);
             }
             // well known primitive type name
             else if (_primitiveTypes.TryGetValue(typeRef.Name, out var primitive))
             {
-                return MakeTypeReference(primitive, typeRef.IsNullable);
+                return MakeTypeReference(primitive, typeRef.Facets.IsNullable);
             }
             // is it known in the included models?
             else if (external.TryGetValue(typeRef.Prefix, out var entry))
@@ -76,12 +76,12 @@ namespace rapid.rdm
                     // TODO: internal error should not occur.
                     throw new TransformationException($"Can not resolve type reference {typeRef.Name}");
                 }
-                return MakeTypeReference(type, typeRef.IsNullable);
+                return MakeTypeReference(type, typeRef.Facets.IsNullable);
             }
             // starting with "Edm."
             else if (typeRef.Name.StartsWith("Edm."))
             {
-                return MakeTypeReference(EdmCoreModel.Instance.FindType(typeRef.Name), typeRef.IsNullable);
+                return MakeTypeReference(EdmCoreModel.Instance.FindType(typeRef.Name), typeRef.Facets.IsNullable);
             }
             else
             {

--- a/tools/rsdl/rapid-cli/rapid.rdm.transformation/rapid.rdm.transformation.csproj
+++ b/tools/rsdl/rapid-cli/rapid.rdm.transformation/rapid.rdm.transformation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Description>RAPID schema definition language to CSDL transformation</Description>
   </PropertyGroup>
 

--- a/tools/rsdl/rapid-cli/rapid.rdm/models/RdmTypeReference.cs
+++ b/tools/rsdl/rapid-cli/rapid.rdm/models/RdmTypeReference.cs
@@ -2,20 +2,47 @@ using System;
 
 namespace rapid.rdm
 {
-    public class RdmTypeReference : IEquatable<RdmTypeReference>
+    public record RdmTypeReferenceFacets
     {
-        public RdmTypeReference(string name, bool isNullable = false, bool isMultivalued = false, Position position = default)
+        public bool IsNullable { get; init; }
+
+        public bool IsMultivalued { get; init; }
+
+        public int? MaxLength { get; init; }
+
+        public int? Precision { get; init; }
+
+        public int? Scale { get; init; }
+
+        public static RdmTypeReferenceFacets None = new RdmTypeReferenceFacets();
+    }
+
+    public sealed class RdmTypeReference : IEquatable<RdmTypeReference>
+    {
+        public RdmTypeReference(string name, RdmTypeReferenceFacets facets, Position position = default)
         {
             Name = name;
-            IsNullable = isNullable;
-            IsMultivalued = isMultivalued;
+            Facets = facets ?? RdmTypeReferenceFacets.None;
+            Position = position;
         }
 
-        public bool IsNullable { get; }
+        public RdmTypeReference(string name, bool isNullable, bool isMultivalued, Position position = default)
+        {
+            Name = name;
+            Facets = new RdmTypeReferenceFacets { IsNullable = isNullable, IsMultivalued = isMultivalued };
+            Position = position;
+        }
 
-        public bool IsMultivalued { get; }
+        public RdmTypeReference(string name, Position position = default)
+        {
+            Name = name;
+            Facets = new RdmTypeReferenceFacets { IsNullable = false, IsMultivalued = false };
+            Position = position;
+        }
 
         public string Name { get; }
+
+        public RdmTypeReferenceFacets Facets { get; }
 
         public Position Position { get; set; }
 
@@ -28,9 +55,9 @@ namespace rapid.rdm
         {
             return
                 string.Equals(one.Name, two.Name) &&
-                one.IsNullable == two.IsNullable &&
-                one.IsMultivalued == two.IsMultivalued;
+                one.Facets.Equals(two.Facets);
         }
+
         public bool Equals(RdmTypeReference other)
         {
             return Equals(this, other);
@@ -38,12 +65,12 @@ namespace rapid.rdm
 
         public override bool Equals(object other)
         {
-            return other is RdmTypeReference model && this.Equals(model);
+            return other is RdmTypeReference model && Equals(this, model);
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Name, IsNullable, IsMultivalued);
+            return HashCode.Combine(Name, Facets);
         }
         #endregion
     }

--- a/tools/rsdl/rapid-cli/rapid.rdm/models/annotations/AnnotationExpression.cs
+++ b/tools/rsdl/rapid-cli/rapid.rdm/models/annotations/AnnotationExpression.cs
@@ -87,9 +87,9 @@ namespace rapid.rdm
         public static AnnotationExpression Object(IEnumerable<ExpressionProperty> properties, Position position = default) =>
             new AnnotationExpression(AnnotationExpressionKind.Object, properties.ToReadOnlyList(), position);
 
-        public IReadOnlyList<ExpressionProperty> Properties => (IReadOnlyList<ExpressionProperty>)Value;
+        public IReadOnlyList<ExpressionProperty> Properties => this.Kind == AnnotationExpressionKind.Object ? (IReadOnlyList<ExpressionProperty>)Value : System.Array.Empty<ExpressionProperty>();
 
-        public IReadOnlyList<AnnotationExpression> Items => (IReadOnlyList<AnnotationExpression>)Value;
+        public IReadOnlyList<AnnotationExpression> Items => this.Kind == AnnotationExpressionKind.Array ? (IReadOnlyList<AnnotationExpression>)Value : System.Array.Empty<AnnotationExpression>();
 
 
         public static bool Equals(AnnotationExpression a, AnnotationExpression b)

--- a/tools/rsdl/rapid-cli/rapid.rdm/rapid.rdm.csproj
+++ b/tools/rsdl/rapid-cli/rapid.rdm/rapid.rdm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Description>RAPID schema definition language abstract syntax tree</Description>
   </PropertyGroup>
 

--- a/tools/rsdl/rapid-cli/rapid.rsdl.tests/ModelEqualityTests.cs
+++ b/tools/rsdl/rapid-cli/rapid.rsdl.tests/ModelEqualityTests.cs
@@ -16,6 +16,9 @@ namespace rapid.rsdl.tests
                 new RdmTypeReference("Integer"),
                 new RdmTypeReference("Integer") },
             new object[] {
+                new RdmTypeReference("String", new RdmTypeReferenceFacets{ MaxLength = 12 }),
+                new RdmTypeReference("String", new RdmTypeReferenceFacets{ MaxLength = 12 }) },
+            new object[] {
                 new RdmProperty("a", new RdmTypeReference("Integer"), false),
                 new RdmProperty("a", new RdmTypeReference("Integer"), false) },
             new object[] {

--- a/tools/rsdl/rapid-cli/rapid.rsdl/rapid.rsdl.csproj
+++ b/tools/rsdl/rapid-cli/rapid.rsdl/rapid.rsdl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adding type facets to String and Decimal type references.
so that the syntax allows  ``` ... | "String" | "Decimal" | "String" "(" number ")"  | "Decimal" "(" number "," number ")" ```
