### PR TITLE
rsdl-js: spaces in doc comments

### DIFF
--- a/tools/rsdl/rsdl-js/lib/parser.js
+++ b/tools/rsdl/rsdl-js/lib/parser.js
@@ -72,7 +72,11 @@ class MyListener extends rsdlListener {
     const docComment = ctx.DOC_COMMENT();
     if (docComment) {
       const name = `${this.annotatable[0].prefix}@Org.OData.Core.V1.Description`;
-      const newText = docComment.getText().substring(2).trim();
+      let newText = docComment.getText().substring(2);
+      // remove trailing \n
+      newText = newText.substring(0, newText.length - 1);
+      // ignore one space immediately following ##, preserve text if there is no space
+      if (newText.startsWith(" ")) newText = newText.substring(1);
       const oldText = this.annotatable[0].target[name];
       this.annotatable[0].target[name] = oldText
         ? `${oldText}\n${newText}`

--- a/tools/rsdl/rsdl-js/test/parser.test.js
+++ b/tools/rsdl/rsdl-js/test/parser.test.js
@@ -406,6 +406,8 @@ describe("Parse correct RSDL", () => {
              ##
              # this is ignored and does not add a line break
              ## has nice properties
+             ##   preserves leading and trailing spaces  
+             ##doesn't require a space after ##
              ## and a cool action
              type foo {
                ## nice property
@@ -437,7 +439,7 @@ describe("Parse correct RSDL", () => {
             $Kind: "ComplexType",
             $OpenType: true,
             "@Org.OData.Core.V1.Description":
-              "good type\n\nhas nice properties\nand a cool action",
+              "good type\n\nhas nice properties\n  preserves leading and trailing spaces  \ndoesn't require a space after ##\nand a cool action",
             bar: { "@Org.OData.Core.V1.Description": "nice property" },
             qux: {},
           },


### PR DESCRIPTION
As discussed in TC call on 2022-05-12
- exactly one space after ## is ignored
- other leading spaces are preserved
- trailing spaces are preserved
- no space after ## required