### PR TITLE
Fix #315 - replace token

### DIFF
--- a/tools/odataUri/src/autocomplete-manager.ts
+++ b/tools/odataUri/src/autocomplete-manager.ts
@@ -4,145 +4,162 @@ import { CharStreams, CommonTokenStream } from "antlr4ts";
 import { ODataUriQueryParser } from "./parsers/ODataUriQueryParser";
 import { ODataUriQueryLexer } from "./parsers/ODataUriQueryLexer";
 import { AutoComplete } from "./autocomplete";
-import { IPathParseResult, parsePath, PathAutoComplete } from './path'
+import { IPathParseResult, parsePath, PathAutoComplete } from "./path";
 import { peekStack, IError } from "./common";
 
+export interface ICompletions {
+  from: number;
+  suggestions: string[];
+}
 
 export class AutoCompleteManager {
-    schema: ISchema;
-    lastInput: string;
-    queryAutoComplete: AutoComplete;
-    queryOptions: SemanticNode;
-    queryParser: ODataUriQueryParser;
-    errors: IError[];
+  schema: ISchema;
+  lastInput: string;
+  queryAutoComplete: AutoComplete;
+  queryOptions: SemanticNode;
+  queryParser: ODataUriQueryParser;
+  errors: IError[];
 
-    pathAutoComplete: PathAutoComplete = null;
+  pathAutoComplete: PathAutoComplete = null;
 
-    pathStart: number = 0;
-    pathEnd: number = 0;
-    queryStart = 0;
-    queryEnd = 0;
+  pathStart: number = 0;
+  pathEnd: number = 0;
+  queryStart = 0;
+  queryEnd = 0;
 
-    separatorPos = 0;
+  separatorPos = 0;
 
-    path: string = '';
-    query: string = '';
+  path: string = "";
+  query: string = "";
 
-    pathResult: IPathParseResult;
+  pathResult: IPathParseResult;
 
-    constructor(schema: ISchema) {
-        this.schema = schema;
-        this.lastInput = null;
-        this.errors = [];
-        this.queryOptions = null;
-        this.queryParser = null;
-        this.queryAutoComplete = null;
+  constructor(schema: ISchema) {
+    this.schema = schema;
+    this.lastInput = null;
+    this.errors = [];
+    this.queryOptions = null;
+    this.queryParser = null;
+    this.queryAutoComplete = null;
+  }
+
+  private parse(input: string) {
+    this.reset();
+    const separatorPos = input.indexOf("?");
+    this.separatorPos = separatorPos;
+    let [path, query] = input.split("?");
+
+    this.pathStart = 0;
+    if (path.startsWith("/")) {
+      path = path.substring(1);
+      this.pathStart = 1;
     }
 
-    private parse(input: string) {
-        this.reset();
-        const separatorPos = input.indexOf('?');
-        this.separatorPos = separatorPos;
-        let [path, query] = input.split('?');
+    this.pathEnd = path.length + this.pathStart - 1;
+    this.path = path;
+    this.parsePath();
 
-        this.pathStart = 0;
-        if (path.startsWith('/')) {
-            path = path.substring(1);
-            this.pathStart = 1;
-        }
-
-
-        this.pathEnd = path.length + this.pathStart - 1;
-        this.path = path;
-        this.parsePath();
-
-        if (path && separatorPos > -1) {
-            this.queryStart = separatorPos + 1;
-            this.queryEnd = this.queryStart + path.length - 1;
-            this.query = query;
-            const pathSegment = peekStack(this.pathResult.segments);
-            this.parseQuery(pathSegment.schemaType);
-        }
-
-        this.lastInput = input;
+    if (path && separatorPos > -1) {
+      this.queryStart = separatorPos + 1;
+      this.queryEnd = this.queryStart + path.length - 1;
+      this.query = query;
+      const pathSegment = peekStack(this.pathResult.segments);
+      this.parseQuery(pathSegment.schemaType);
     }
 
-    private parsePath() {
-        this.pathResult = parsePath(this.path, this.schema, this.pathStart)
-        this.errors.push(...this.pathResult.errors.map(err => {
-            err.range.start += this.pathStart;
-            err.range.stop += this.pathStart;
-            return err;
-        }));
-        this.pathAutoComplete = new PathAutoComplete(this.path, this.schema, this.pathResult.segments);
+    this.lastInput = input;
+  }
+
+  private parsePath() {
+    this.pathResult = parsePath(this.path, this.schema, this.pathStart);
+    this.errors.push(
+      ...this.pathResult.errors.map((err) => {
+        err.range.start += this.pathStart;
+        err.range.stop += this.pathStart;
+        return err;
+      })
+    );
+    this.pathAutoComplete = new PathAutoComplete(
+      this.path,
+      this.schema,
+      this.pathResult.segments
+    );
+  }
+
+  private parseQuery(rootType: ISchemaType) {
+    const input = this.query;
+    const inputStream = CharStreams.fromString(input);
+    const queryLexer = new ODataUriQueryLexer(inputStream);
+    const tokens = new CommonTokenStream(queryLexer);
+    const queryParser = new ODataUriQueryParser(tokens);
+    const ast = queryParser.queryOptions();
+
+    const semanticResult = parseQueryOptionsSemantics(
+      ast,
+      this.schema,
+      rootType
+    );
+    this.queryOptions = semanticResult.tree;
+    this.errors.push(
+      ...semanticResult.errors.map((err) => {
+        err.range.start += this.queryStart;
+        err.range.stop += this.queryStart;
+        return err;
+      })
+    );
+    this.lastInput = input;
+    this.queryParser = queryParser;
+    this.queryAutoComplete = new AutoComplete(
+      queryParser,
+      semanticResult.syntaxSemanticMap,
+      semanticResult.schema
+    );
+  }
+
+  updateSchema(schema: ISchema) {
+    this.schema = schema;
+    // reset everything
+    this.reset();
+  }
+
+  reset() {
+    this.lastInput = null;
+    this.errors = [];
+    this.pathResult = null;
+    this.queryOptions = null;
+    this.queryParser = null;
+    this.queryAutoComplete = null;
+    this.pathAutoComplete = null;
+  }
+
+  getErrors(input: string) {
+    if (!this.schema) return [];
+
+    if (input === this.lastInput) {
+      return this.errors;
     }
 
-    private parseQuery(rootType: ISchemaType) {
-        const input = this.query;
-        const inputStream = CharStreams.fromString(input);
-        const queryLexer = new ODataUriQueryLexer(inputStream);
-        const tokens = new CommonTokenStream(queryLexer);
-        const queryParser = new ODataUriQueryParser(tokens);
-        const ast = queryParser.queryOptions();
+    this.parse(input);
+    return this.errors;
+  }
 
-        const semanticResult = parseQueryOptionsSemantics(ast, this.schema, rootType);
-        this.queryOptions = semanticResult.tree;
-        this.errors.push(...semanticResult.errors.map(err => {
-            err.range.start += this.queryStart;
-            err.range.stop += this.queryStart;
-            return err;
-        }));
-        this.lastInput = input;
-        this.queryParser = queryParser;
-        this.queryAutoComplete = new AutoComplete(queryParser, semanticResult.syntaxSemanticMap, semanticResult.schema);
+  getCompletions(input: string, pos: number): ICompletions {
+    if (!this.schema) return { from: pos, suggestions: [] };
+
+    if (input !== this.lastInput) {
+      this.parse(input);
     }
 
-    updateSchema(schema: ISchema) {
-        this.schema = schema;
-        // reset everything
-        this.reset();
-
+    if (this.separatorPos > -1 && pos >= this.separatorPos) {
+      // query
+      const relativePos = pos - this.queryStart;
+      const suggestions = this.queryAutoComplete.getSuggestions(relativePos);
+      //TODO: from
+      return { from: pos, suggestions };
+    } else {
+      // path
+      const suggestions = this.pathAutoComplete.getCompletions(pos);
+      return { from: input.lastIndexOf("/") + 1, suggestions };
     }
-
-    reset() {
-        this.lastInput = null;
-        this.errors = [];
-        this.pathResult = null;
-        this.queryOptions = null;
-        this.queryParser = null;
-        this.queryAutoComplete = null;
-        this.pathAutoComplete = null;
-    }
-
-    getErrors(input: string) {
-        if (!this.schema) return [];
-
-        if (input === this.lastInput) {
-            return this.errors;
-        }
-
-        this.parse(input);
-        return this.errors;
-    }
-
-    getCompletions(input: string, pos: number) {
-        if (!this.schema) return [];
-
-        if (input !== this.lastInput) {
-            this.parse(input);
-        }
-
-        if (this.separatorPos > - 1 && pos >= this.separatorPos) {
-            // query
-            const relativePos = pos - this.queryStart;
-            const suggestions = this.queryAutoComplete.getSuggestions(relativePos);
-            return suggestions;
-        }
-        else {
-            // path
-            const suggestions = this.pathAutoComplete.getCompletions(pos);
-            return suggestions;
-        }
-
-    }
+  }
 }

--- a/tools/odataUri/src/index.ts
+++ b/tools/odataUri/src/index.ts
@@ -1,1 +1,1 @@
-export { AutoCompleteManager } from "./autocomplete-manager";
+export { ICompletions, AutoCompleteManager } from "./autocomplete-manager";

--- a/tools/odataUri/test/autocomplete-manager.test.ts
+++ b/tools/odataUri/test/autocomplete-manager.test.ts
@@ -14,31 +14,43 @@ const jetsons: ISchema = JSON.parse(
 describe("odataUri", () => {
   it("completions for empty input", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, { "": ["competitors", "company"] });
+    expectCompletions(manager, "", ["competitors", "company"]);
   });
 
   it("completions for prefix", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, { com: ["competitors", "company"] });
+    expectCompletions(manager, "com", ["competitors", "company"]);
   });
 
   it("completions for prefix with slash - why needed?", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, { "/com": ["competitors", "company"] });
+    expectCompletions(manager, "/com", ["competitors", "company"], 1);
   });
 
   it("completions for singleton", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, {
-      "company?": [
+    expectCompletions(
+      manager,
+      "company?",
+      [
         "$filter", //TODO: should not be suggested
         "$select",
         "$expand",
         "$top", //TODO: should not be suggested
         "$skip", //TODO: should not be suggested] });
       ],
-      "company/": ["stockSymbol", "name", "incorporated", "employees"],
-      "company/employees?": [
+      7
+    );
+    expectCompletions(
+      manager,
+      "company/",
+      ["stockSymbol", "name", "incorporated", "employees"],
+      8
+    );
+    expectCompletions(
+      manager,
+      "company/employees?",
+      [
         "$filter",
         "$select",
         "$expand",
@@ -46,13 +58,16 @@ describe("odataUri", () => {
         "$skip",
         //TODO: $orderby should also be suggested
       ],
-    });
+      17
+    );
   });
 
   it("completions for entity set", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, {
-      "competitors?": [
+    expectCompletions(
+      manager,
+      "competitors?",
+      [
         "$filter",
         "$select",
         "$expand",
@@ -60,13 +75,29 @@ describe("odataUri", () => {
         "$skip",
         //TODO: $orderby should also be suggested
       ],
-      "competitors/": [
+      11
+    );
+    expectCompletions(
+      manager,
+      "competitors/",
+      [
         "$count",
         "(", //TODO: a paren after a slash is syntactically incorrect
       ],
-      "competitors/foo": ["$count", "("], //TODO: this doesn't make sense
-      "competitors/123": ["$count", "("], //TODO: this doesn't make sense
-    });
+      12
+    );
+    expectCompletions(
+      manager,
+      "competitors/foo",
+      ["$count", "("], //TODO: this doesn't make sense
+      12
+    );
+    expectCompletions(
+      manager,
+      "competitors/123",
+      ["$count", "("], //TODO: this doesn't make sense
+      12
+    );
   });
 
   it("completions for entity set after updateSchema", () => {
@@ -75,13 +106,13 @@ describe("odataUri", () => {
     const errors = manager.getErrors("foo");
     expect(errors).to.be.empty;
 
-    expectCompletions(manager, {
-      "competitors?": [],
-    });
+    expectCompletions(manager, "competitors?", [], 11);
 
     manager.updateSchema(jetsons);
-    expectCompletions(manager, {
-      "competitors?": [
+    expectCompletions(
+      manager,
+      "competitors?",
+      [
         "$filter",
         "$select",
         "$expand",
@@ -89,71 +120,64 @@ describe("odataUri", () => {
         "$skip",
         //TODO: $orderby should also be suggested
       ],
-    });
+      11
+    );
   });
 
   it("completions for $select", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, {
-      "competitors?$select": ["="],
-      "competitors?$select=": [
-        "stockSymbol",
-        "name",
-        "incorporated",
-        "employees",
-      ],
-      "competitors?$select=stockSymbol": [
-        "&",
-        "stockSymbol",
-        "name",
-        "incorporated",
-        "employees",
-        ",",
-      ],
-    });
+    expectCompletions(manager, "competitors?$select", ["="], 18);
+    expectCompletions(
+      manager,
+      "competitors?$select=",
+      ["stockSymbol", "name", "incorporated", "employees"],
+      19
+    );
+    expectCompletions(
+      manager,
+      "competitors?$select=stockSymbol",
+      ["&", "stockSymbol", "name", "incorporated", "employees", ","],
+      30
+    );
   });
 
   it("completions for $expand", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, {
-      "company?$expand": ["="],
-      "company?$expand=": ["employees"],
-      "company?$expand=employees": ["&", "employees", ","],
-    });
+    expectCompletions(manager, "company?$expand", ["="], 14);
+    expectCompletions(manager, "company?$expand=", ["employees"], 15);
+    expectCompletions(
+      manager,
+      "company?$expand=employees",
+      ["&", "employees", ","],
+      24
+    );
   });
 
   it("completions for $filter", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, {
-      "company?$filter": ["="],
-      "company?$filter=": [
-        "stockSymbol",
-        "name",
-        "incorporated",
-        "employees",
-        "true",
-        "false",
-      ],
-      "company?$filter=stocksymbol": [
-        "eq",
-        "ne",
-        "gt",
-        "ge",
-        "lt",
-        "le",
-        "and",
-        "or",
-        "&",
-      ],
-      "company?$filter=stocksymbol eq": [
-        "stockSymbol",
-        "name",
-        "incorporated",
-        "employees",
-        "true",
-        "false",
-      ],
-      "company?$filter=stocksymbol eq 123": [
+    expectCompletions(manager, "company?$filter", ["="], 14);
+    expectCompletions(
+      manager,
+      "company?$filter=",
+      ["stockSymbol", "name", "incorporated", "employees", "true", "false"],
+      15
+    );
+    expectCompletions(
+      manager,
+      "company?$filter=stocksymbol",
+      ["eq", "ne", "gt", "ge", "lt", "le", "and", "or", "&"],
+      26
+    );
+    expectCompletions(
+      manager,
+      "company?$filter=stocksymbol eq",
+      ["stockSymbol", "name", "incorporated", "employees", "true", "false"],
+      29
+    );
+    expectCompletions(
+      manager,
+      "company?$filter=stocksymbol eq 123",
+      [
         "eq", //TODO: makes no sense here
         "ne", //TODO: makes no sense here
         "gt", //TODO: makes no sense here
@@ -164,7 +188,12 @@ describe("odataUri", () => {
         "or",
         "&",
       ],
-      "company?$filter=stocksymbol eq 'FOO'": [
+      33
+    );
+    expectCompletions(
+      manager,
+      "company?$filter=stocksymbol eq 'FOO'",
+      [
         "eq", //TODO: makes no sense here
         "ne", //TODO: makes no sense here
         "gt", //TODO: makes no sense here
@@ -175,15 +204,23 @@ describe("odataUri", () => {
         "or",
         "&",
       ],
-      "company?$filter=(stocksymbol eq true": [], //TODO: would expect closing paren
-    });
+      35
+    );
+    expectCompletions(
+      manager,
+      "company?$filter=(stocksymbol eq true",
+      [], //TODO: would expect closing paren
+      35
+    );
   });
 
   it("completions for $orderby", () => {
     const manager = new AutoCompleteManager(jetsons);
-    expectCompletions(manager, {
+    expectCompletions(
+      manager,
       // "company?$orderby": ["="],
-      "company?$orderby=": [
+      "company?$orderby=",
+      [
         "stockSymbol",
         "stockSymbol desc",
         "name",
@@ -193,7 +230,12 @@ describe("odataUri", () => {
         "employees", //TODO: that doesn't make much sense
         "employees desc", //TODO: that doesn't make much sense
       ],
-      "company?$orderby=name": [
+      16
+    );
+    expectCompletions(
+      manager,
+      "company?$orderby=name",
+      [
         "&",
         "stockSymbol",
         "stockSymbol desc",
@@ -205,22 +247,19 @@ describe("odataUri", () => {
         "employees desc", //TODO: that doesn't make much sense
         //TODO: would have expected "," here
       ],
-    });
+      20
+    );
   });
 
   it("completions for $skip & $top", () => {
     const manager = new AutoCompleteManager(jetsons);
-    // expectCompletions(manager, {
+    // "competitors?$skip": [???], //TODO: throws exception
+    expectCompletions(manager, "competitors?$skip=", ["NUMBER"], 17);
+    expectCompletions(manager, "competitors?$skip=3", ["&"], 18);
 
-    // });
-    expectCompletions(manager, {
-      // "competitors?$skip": [???], //TODO: throws exception
-      "competitors?$skip=": ["NUMBER"],
-      "competitors?$skip=3": ["&"],
-      // "competitors?$top": [???], //TODO: throws exception
-      "competitors?$top=": ["NUMBER"],
-      "competitors?$top=3": ["&"],
-    });
+    // "competitors?$top": [???], //TODO: throws exception
+    expectCompletions(manager, "competitors?$top=", ["NUMBER"], 16);
+    expectCompletions(manager, "competitors?$top=3", ["&"], 17);
   });
 
   it("errors for invalid input", () => {
@@ -255,10 +294,11 @@ interface IExpectation {
 
 function expectCompletions(
   manager: AutoCompleteManager,
-  expected: IExpectation
+  input: string,
+  suggestions: string[],
+  from: number = 0
 ) {
-  for (const [input, completions] of Object.entries(expected)) {
-    const actual = manager.getCompletions(input, input.length - 1);
-    expect(actual.suggestions).to.eql(completions, input);
-  }
+  const actual = manager.getCompletions(input, input.length - 1);
+  expect(actual.suggestions).to.eql(suggestions, input);
+  expect(actual.from).to.eql(from, input);
 }

--- a/tools/odataUri/test/autocomplete-manager.test.ts
+++ b/tools/odataUri/test/autocomplete-manager.test.ts
@@ -2,12 +2,14 @@ import { expect } from "chai";
 import { readFileSync } from "fs";
 import "mocha";
 
-import { AutoCompleteManager } from "../src/autocomplete-manager";
+import { ICompletions, AutoCompleteManager } from "../src/autocomplete-manager";
 import { ISchema } from "../src/json-model";
 
 const jetsons: ISchema = JSON.parse(
   readFileSync(`${__dirname}/resources/jetsons.csdl.json`, "utf8")
 );
+
+//TODO: also expect "from" for completions
 
 describe("odataUri", () => {
   it("completions for empty input", () => {
@@ -257,6 +259,6 @@ function expectCompletions(
 ) {
   for (const [input, completions] of Object.entries(expected)) {
     const actual = manager.getCompletions(input, input.length - 1);
-    expect(actual).to.eql(completions, input);
+    expect(actual.suggestions).to.eql(completions, input);
   }
 }


### PR DESCRIPTION
Part of #315 
- replace entire token - in path only, query options work completely different

Works for api-designer and odata-explorer

Works partially for https://rapid.rocks/docs/rapid-read: no completions for first path segment