### PR TITLE
Include JS tests in csdl-xml in npm test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ obj/
 Thumbs.db
 UserInterfaceState.xcuserstate
 *.bak
+tools/csdl-xml/test/resources/*.csdl.xml

--- a/tools/.vscode/settings.json
+++ b/tools/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "mochaExplorer.files": "*/test/**/*.ts",
-    "mochaExplorer.require": "ts-node/register",
-    "[typescript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
+  "mochaExplorer.files": "*/test/**/*.[jt]s",
+  "mochaExplorer.require": "ts-node/register",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true
 }

--- a/tools/csdl-xml/test/cli.test.js
+++ b/tools/csdl-xml/test/cli.test.js
@@ -11,15 +11,17 @@ describe("CLI", () => {
   });
 
   it("Translate one file", async () => {
-    const outfile = "test/resources/jetsons-enhanced.csdl.xml";
-    const basefile = "test/resources/jetsons-enhanced.csdl.base.xml";
+    const outfile = `${__dirname}/resources/jetsons-enhanced.csdl.xml`;
+    const basefile = `${__dirname}/resources/jetsons-enhanced.csdl.base.xml`;
     if (fs.existsSync(outfile)) fs.unlinkSync(outfile);
     const result = await cmd(
-      ["-p", "resources/jetsons-enhanced.csdl.json"],
-      "test"
+      ["-p", `${__dirname}/resources/jetsons-enhanced.csdl.json`],
+      __dirname
     );
     expect(result.code).to.equal(0);
-    expect(result.stdout).to.equal("resources/jetsons-enhanced.csdl.xml\n");
+    expect(result.stdout).to.equal(
+      `${__dirname}/resources/jetsons-enhanced.csdl.xml\n`
+    );
     expect(fs.existsSync(outfile)).to.equal(true);
     const basexml = fs.readFileSync(basefile, "utf-8");
     const xml = fs.readFileSync(outfile, "utf-8");
@@ -27,10 +29,10 @@ describe("CLI", () => {
   });
 
   it("Translate file with includes", async () => {
-    const outfile = "test/resources/main.csdl.xml";
-    const basefile = "test/resources/main.csdl.base.xml";
+    const outfile = `${__dirname}/resources/main.csdl.xml`;
+    const basefile = `${__dirname}/resources/main.csdl.base.xml`;
     if (fs.existsSync(outfile)) fs.unlinkSync(outfile);
-    const result = await cmd(["-p", "resources/main.csdl.json"], "test");
+    const result = await cmd(["-p", "resources/main.csdl.json"], __dirname);
     expect(result.code).to.equal(0);
     expect(result.stdout).to.equal("resources/main.csdl.xml\n");
     expect(fs.existsSync(outfile)).to.equal(true);
@@ -56,7 +58,7 @@ describe("CLI - error cases", () => {
   });
 
   it("File with syntax errors", async () => {
-    const result = await cmd(["-p", "resources/kaputt.csdl.json"], "test");
+    const result = await cmd(["-p", "resources/kaputt.csdl.json"], __dirname);
     expect(result.code).to.equal(0);
     expect(result.stdout).to.contain("Unexpected Schema Element");
   });
@@ -65,7 +67,7 @@ describe("CLI - error cases", () => {
 function cmd(args, cwd) {
   return new Promise((resolve) => {
     exec(
-      `node ${path.resolve("./lib/cli")} ${args.join(" ")}`,
+      `node ${path.resolve(`${__dirname}/../lib/cli`)} ${args.join(" ")}`,
       { cwd },
       (error, stdout, stderr) => {
         resolve({

--- a/tools/csdl-xml/test/cli.test.js
+++ b/tools/csdl-xml/test/cli.test.js
@@ -10,13 +10,13 @@ describe("csdl-xml CLI", () => {
     expect(result.stdout).to.contain("Usage: csdl2xml");
   });
 
-  it("Translate one file", async () => {
+  it("Translate one file specified with full path", async () => {
     const outfile = `${__dirname}/resources/jetsons-enhanced.csdl.xml`;
     const basefile = `${__dirname}/resources/jetsons-enhanced.csdl.base.xml`;
     if (fs.existsSync(outfile)) fs.unlinkSync(outfile);
     const result = await cmd(
       ["-p", `${__dirname}/resources/jetsons-enhanced.csdl.json`],
-      __dirname
+      `${__dirname}/..`
     );
     expect(result.code).to.equal(0);
     expect(result.stdout).to.equal(
@@ -28,7 +28,7 @@ describe("csdl-xml CLI", () => {
     expect(xml).to.equal(basexml);
   });
 
-  it("Translate file with includes", async () => {
+  it("Translate file (specified with relative path) with includes", async () => {
     const outfile = `${__dirname}/resources/main.csdl.xml`;
     const basefile = `${__dirname}/resources/main.csdl.base.xml`;
     if (fs.existsSync(outfile)) fs.unlinkSync(outfile);

--- a/tools/csdl-xml/test/cli.test.js
+++ b/tools/csdl-xml/test/cli.test.js
@@ -3,7 +3,7 @@ const exec = require("child_process").exec;
 const fs = require("fs");
 const path = require("path");
 
-describe("CLI", () => {
+describe("csdl-xml CLI", () => {
   it("Help", async () => {
     const result = await cmd(["-h"]);
     expect(result.code).to.equal(0);
@@ -42,7 +42,7 @@ describe("CLI", () => {
   });
 });
 
-describe("CLI - error cases", () => {
+describe("csdl-xml CLI - error cases", () => {
   it("Invalid option", async () => {
     const result = await cmd(["-x"]);
     expect(result.code).to.equal(0);

--- a/tools/csdl-xml/test/xmlSerializer.test.js
+++ b/tools/csdl-xml/test/xmlSerializer.test.js
@@ -6,7 +6,7 @@ function stripWhitespace(inputString) {
   return inputString.replace(/\s/g, "");
 }
 
-describe("Parse correct JSON CSDL", () => {
+describe("csdl-xml Parse correct JSON CSDL", () => {
   it("Empty Object", () => {
     const xml = serializeToXml({});
     assert.equal(

--- a/tools/odataUri/src/semantic-model.ts
+++ b/tools/odataUri/src/semantic-model.ts
@@ -641,7 +641,7 @@ export class QueryOptionsVisitor
     this.typeStack.push(itemType);
 
     const orderSpec = ctx.tryGetRuleContext(0, OrderSpecContext);
-    console.log("order spec", orderSpec);
+    // console.log("order spec", orderSpec);
     if (orderSpec) {
       const field = orderSpec.tryGetRuleContext(0, OrderFieldContext);
       const fieldNode = field && this.visitOrderField(field);

--- a/tools/package.json
+++ b/tools/package.json
@@ -15,7 +15,7 @@
     "postinstall": "patch-package",
     "api-designer": "cd api-designer && npm start",
     "api-explorer": "cd api-explorer && npm start",
-    "test": "c8 mocha -r ts-node/register */test/**/*.test.ts"
+    "test": "c8 mocha -r ts-node/register */test/**/*.test.[jt]s"
   },
   "devDependencies": {
     "patch-package": "^6.4.7",


### PR DESCRIPTION
* `npm test` in folder `tools` now also runs tests from `csdl-xml`
* the tests can still be run via `npm test` in folder `tools/csdl-xml`
* if `tools` folder is opened with VS Code and the recommended extensions are installed, the Mocha Test Adapter extension will run all tests of sub-projects of `tools` , including `csdl-xml`
![image](https://user-images.githubusercontent.com/951576/184226058-40ee0c73-0071-4e8f-9569-614a22bfcfac.png)


