### PR TITLE
Support multi-line requests in urlEditor

### DIFF
--- a/tools/urlEditor/src/uri-editor.ts
+++ b/tools/urlEditor/src/uri-editor.ts
@@ -21,7 +21,7 @@ function initUrlEditor(
   const manager = new AutoCompleteManager(null);
 
   const completionSource: CompletionSource = (context) => {
-    const content = context.state.doc.line(1).text;
+    const content = getDocContent(context.state.doc);
 
     let completions: ICompletions;
 
@@ -47,7 +47,7 @@ function initUrlEditor(
   };
 
   const linterSource = (view: EditorView): Diagnostic[] => {
-    const content = view.state.doc.line(1).text;
+    const content = getDocContent(view.state.doc);
     const errors = manager.getErrors(content);
 
     return errors.map((error) => ({


### PR DESCRIPTION
Fixes #420

Previously, urlEditor only looked at the first line of the editbox, so suggestions were fixed based on only the first line.

With this change, the entire request is considered for statement completion and linting.